### PR TITLE
Remove rogue 'else'

### DIFF
--- a/bin/imp-migrate.js
+++ b/bin/imp-migrate.js
@@ -19,8 +19,7 @@ function apiKeyPrompt(env, apiKey, next) {
   promptText += ": ";
 
   prompt(promptText, function(val){
-
-    else if (!apiKey && !val) {
+    if (!apiKey && !val) {
       apiKeyPrompt(env, apiKey, next);
       return;
     }


### PR DESCRIPTION
”imp migrate -h” fails – remove 'else' in line 23 to fix this
